### PR TITLE
set email to lowercase upon registering

### DIFF
--- a/src/app/Model/User.php
+++ b/src/app/Model/User.php
@@ -145,6 +145,7 @@ class User extends AppModel
     if (isset($this->data[$this->alias]['password'])) {
       $this->data[$this->alias]['password'] = AuthComponent::password($this->data[$this->alias]['password']);
     }
+    $this->data[$this->alias]['email'] = strtolower($this->data[$this->alias]['email']);
     return true;
   }
   public function afterFind($results, $primary = false)


### PR DESCRIPTION
Hey!

GELOS gave a workshop about open source contributions at semcomp today :). On the second half, we attempted to fix a real issue any of the students brought, and this was the one we chose to implement.

The issue is that currently, when registering, emails are treated case sensitively; which should not be the case.

This (very small) PR fixes it so that they are transformed to lowercase.