### PR TITLE
FIX: XSS in exercise case output

### DIFF
--- a/src/app/View/CommitsExerciseCases/view_case.ctp
+++ b/src/app/View/CommitsExerciseCases/view_case.ctp
@@ -17,7 +17,7 @@
             <div class="row">
                 <div class="col-md-6">
                     <p><?php echo __("Expected Output"); ?></p>
-                    <pre><?php echo $exerciseCase['ExerciseCase']['output']; ?></pre>
+                    <pre><?php echo h($exerciseCase['ExerciseCase']['output']); ?></pre>
                     <button class="btn btn-info" id="btnCopyClipboardOutput" data-clipboard-target="expectedOutputField"><?php echo __("Copy to Clipboard"); ?></button>
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
### FIX: XSS in exercise case output
The goal of this Pull Request is to fix a Reflected Cross-Site Scripting vulnerability found in the user's exercise output. This vulnerability would allow, for example, cookie-hijacking of administrators.

The original vulnerability consisted of sending a file with a print of an arbitrary JavaScript script

for example, in C:

` printf("<script>alert(1)</script>") ` 

In this case, the browser would interpret this output as code and execute it on the back-end, thus generating an alert.


### How the fix was made:

One of the simplest and most effective ways to resolve this vulnerability is to use the `h()` function, available in CakePHP. The purpose of this function is to handle special characters in HTML, for example:

`<` becomes `&lt;`

This allows us to filter user output, preventing malicious users from entering the data and improving code security.